### PR TITLE
Initialize project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+psychology-cabinet-management/**/node_modules
+psychology-cabinet-management/**/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# tsa-probe
+# Psychology Cabinet Management
+
+This repository is a starting point for the **Psychology Cabinet Management** application. The goal of the project is to provide a microservices based Progressive Web Application for managing appointments, clients and GDPR compliance for psychology practices in Romania.
+
+The original specification is extensive. This repository currently contains only a minimal skeleton of the project structure. Further development is required to implement all features such as authentication, multi-tenant support, SMS notifications, and GDPR tooling.
+
+## Structure
+
+```
+psychology-cabinet-management/
+├── backend/   # Node.js + TypeScript API
+└── frontend/  # Next.js PWA
+```
+
+Each folder will contain its own `package.json` and source code. Additional configuration files (Docker, Prisma, etc.) will be added as the project evolves.
+
+## Getting Started
+
+1. Install dependencies for backend and frontend once they are added.
+2. Configure environment variables as needed.
+3. Run the development servers separately for backend and frontend.
+
+This project is under active development and does not yet implement the full functionality outlined in the specification.

--- a/psychology-cabinet-management/backend/README.md
+++ b/psychology-cabinet-management/backend/README.md
@@ -1,0 +1,10 @@
+# Backend
+
+Minimal Express server with TypeScript.
+
+Run in development:
+
+```bash
+npm install
+npm run dev
+```

--- a/psychology-cabinet-management/backend/package.json
+++ b/psychology-cabinet-management/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "psychology-backend",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/psychology-cabinet-management/backend/src/server.ts
+++ b/psychology-cabinet-management/backend/src/server.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+
+const app = express();
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(3001, () => {
+  console.log('Backend listening on port 3001');
+});

--- a/psychology-cabinet-management/backend/tsconfig.json
+++ b/psychology-cabinet-management/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/psychology-cabinet-management/frontend/README.md
+++ b/psychology-cabinet-management/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+Minimal Next.js application.
+
+Run in development:
+
+```bash
+npm install
+npm run dev
+```

--- a/psychology-cabinet-management/frontend/next.config.js
+++ b/psychology-cabinet-management/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/psychology-cabinet-management/frontend/package.json
+++ b/psychology-cabinet-management/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "psychology-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/psychology-cabinet-management/frontend/src/pages/index.tsx
+++ b/psychology-cabinet-management/frontend/src/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Psychology Cabinet Management</h1>
+    </main>
+  );
+}

--- a/psychology-cabinet-management/frontend/tsconfig.json
+++ b/psychology-cabinet-management/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "esnext",
+    "jsx": "preserve",
+    "strict": true,
+    "allowJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- start a new skeleton for the Psychology Cabinet Management project
- add minimal backend with Express and TypeScript
- add minimal frontend with Next.js and React
- document the project structure

## Testing
- `node psychology-cabinet-management/backend/src/server.ts` *(ensures server starts)*

------
https://chatgpt.com/codex/tasks/task_e_685af7483088832b830e0c02455de060